### PR TITLE
Login Page Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,26 @@ go run ./cmd/server
 
 This will launch the IdP on port `8080` by default.
 
+# Configuration
+
+The IdP supports a few configuration options that can be obtained from environment variables:
+
+| Key    | Description                                                                        | Default                 |
+|--------|------------------------------------------------------------------------------------|-------------------------|
+| `PORT` | Controls which port that the IdP will bind to                                      | `8080`                  |
+| `HOST` | The DNS host that the IdP will use when constructing URLs in the metadata endpoint | `http://localhost:8080` |
+
+For more complex configuration, the IdP expects a `config.yml` file to exist either beside the executable or in `/etc/test-saml-idp`.
+
+Please refer to `config.example.yml` for more information.
+
 # Docker Image
 
 Each tagged release is published on [GHCR](https://github.com/derekmckinnon/test-saml-idp/pkgs/container/test-saml-idp).
 
 Simply `docker pull` or add the image to your `docker-compose.yml` file.
 
-To run the container, you will need to volume mount your customized `config.yml` file into `/app/config.yml`.
-
-Future releases should add a lot more configuration options (`env`s and flags) to enable more convenient configuration
-scenarios.
+To run the container, you will need to volume mount your customized `config.yml` file into `/app/config.yml` or `/etc/test-saml-idp/config.yml`.
 
 If you have a specific architecture in mind that isn't currently supported, please
 [open an Issue](https://github.com/derekmckinnon/test-saml-idp/issues/new). PRs are welcomed too :upside_down_face:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,7 +7,6 @@ import (
 	idp "github.com/derekmckinnon/test-saml-idp"
 	"github.com/spf13/viper"
 	"log"
-	"net/url"
 	"os"
 )
 
@@ -17,11 +16,6 @@ func main() {
 	config, err := loadConfig()
 	if err != nil {
 		log.Fatalf("error loading configuration: %v", err)
-	}
-
-	baseUrl, err := url.Parse(config.Host)
-	if err != nil {
-		log.Fatalf("cannot parse base URL: %v", err)
 	}
 
 	key, err := loadPrivateKey()
@@ -36,7 +30,7 @@ func main() {
 
 	log.Println("Initializing IdP Server...")
 	server := idp.New(idp.ServerOptions{
-		BaseUrl:     *baseUrl,
+		Config:      config,
 		Key:         key,
 		Certificate: certificate,
 	})

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,18 +1,18 @@
-login_page:
-  title: "Login to Foobar"
-  dump_users: true
-  description: |
+login_page: # Optional
+  title: "Login to Foobar" # Optional, defaults to "Login"
+  dump_users: true # Optional, defaults to false
+  description: | # Optional, defaults to empty string
     **This is a test IdP**
     
     This is a _test_ of [Markdown](https://github.com/gomarkdown/markdown) rendering.
 
-services:
-  - entity_id: "foobar"
-    assertion_consumer_service: "http://localhost:5000"
+services: # Required
+  - entity_id: "foobar" # Required
+    assertion_consumer_service: "http://localhost:5000" # Required
 
-users:
-  - username: "test"
-    email: "test@test.com"
-    password: "test"
-    first_name: "Test"
-    last_name: "User"
+users: # Required
+  - username: "test" # Required
+    email: "test@test.com" # Required
+    password: "test" # Required
+    first_name: "Test" # Required
+    last_name: "User" # Required

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,3 +1,11 @@
+login_page:
+  title: "Login to Foobar"
+  dump_users: true
+  description: |
+    **This is a test IdP**
+    
+    This is a _test_ of [Markdown](https://github.com/gomarkdown/markdown) rendering.
+
 services:
   - entity_id: "foobar"
     assertion_consumer_service: "http://localhost:5000"

--- a/config.go
+++ b/config.go
@@ -1,9 +1,10 @@
 package idp
 
 type Config struct {
-	Host     string
-	Services []Service
-	Users    []User
+	Host             string           `mapstructure:"host"`
+	Services         []Service        `mapstructure:"services"`
+	Users            []User           `mapstructure:"users"`
+	LoginPageOptions LoginPageOptions `mapstructure:"login_page"`
 }
 
 type Service struct {
@@ -12,9 +13,15 @@ type Service struct {
 }
 
 type User struct {
-	Username  string
-	Email     string
-	Password  string
+	Username  string `mapstructure:"username"`
+	Email     string `mapstructure:"email"`
+	Password  string `mapstructure:"password"`
 	FirstName string `mapstructure:"first_name"`
 	LastName  string `mapstructure:"last_name"`
+}
+
+type LoginPageOptions struct {
+	Title       string `mapstructure:"title"`
+	Description string `mapstructure:"description"`
+	DumpUsers   bool   `mapstructure:"dump_users"`
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20220905174103-7b278df48cfb // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/gomarkdown/markdown v0.0.0-20220905174103-7b278df48cfb h1:7h+tPfwoUE+qLvWYmsvKSiRlXv6WGorb6PUKaZUclwc=
+github.com/gomarkdown/markdown v0.0.0-20220905174103-7b278df48cfb/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/options.go
+++ b/options.go
@@ -3,22 +3,10 @@ package idp
 import (
 	"crypto"
 	"crypto/x509"
-	"net/url"
-	"strings"
 )
 
 type ServerOptions struct {
-	BaseUrl     url.URL
+	Config      *Config
 	Key         crypto.PrivateKey
 	Certificate *x509.Certificate
-}
-
-func (o *ServerOptions) getBasePath() string {
-	basePath := o.BaseUrl.Path
-
-	if basePath == "" || basePath == "/" {
-		return "/"
-	}
-
-	return strings.TrimSuffix(basePath, "/")
 }

--- a/templates/login.tmpl
+++ b/templates/login.tmpl
@@ -5,22 +5,55 @@
 {{define "content"}}
     <div class="row justify-content-center">
         <div class="col-4">
-            <h1>Login</h1>
+            <h1 class="mt-3 text-center">{{.Title}}</h1>
+
+            {{if .Description }}
+                <div class="mt-3">
+                    {{.Description}}
+                </div>
+            {{end}}
+
+            {{if .Users}}
+                <div class="mt-3">
+                    <h2>Test Accounts</h2>
+                    <table class="table table-sm">
+                        <thead>
+                        <tr>
+                            <th>Username</th>
+                            <th>Password</th>
+                            <th>Email</th>
+                            <th>First Name</th>
+                            <th>Last Name</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            {{range .Users}}
+                                <tr>
+                                    <td>{{.Username}}</td>
+                                    <td>{{.Password}}</td>
+                                    <td>{{.Email}}</td>
+                                    <td>{{.FirstName}}</td>
+                                    <td>{{.LastName}}</td>
+                                </tr>
+                            {{end}}
+                        </tbody>
+                    </table>
+                </div>
+            {{end}}
 
             {{if .Toast}}
-                <div class="alert alert-danger">
+                <div class="mt-3 alert alert-danger">
                     {{.Toast}}
                 </div>
             {{end}}
 
-            <form action="{{.Url}}" method="post">
+            <form action="{{.Url}}" method="post" autocomplete="off" class="mt-3">
                 <input type="hidden" name="SAMLRequest" value="{{.SamlRequest}}">
                 <input type="hidden" name="RelayState" value="{{.RelayState}}">
 
                 <div class="mb-3">
                     <label for="username" class="form-label">Username:</label>
-                    <input type="text" name="username" id="username" value="{{.Username}}" class="form-control" required
-                           autofocus>
+                    <input type="text" name="username" id="username" value="{{.Username}}" class="form-control" required autofocus>
                 </div>
 
                 <div class="mb-3">

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,8 @@
 package idp
 
 import (
+	"github.com/gomarkdown/markdown"
+	"html/template"
 	"net/url"
 	"strings"
 )
@@ -13,4 +15,11 @@ func getBasePath(u url.URL) string {
 	}
 
 	return strings.TrimSuffix(basePath, "/")
+}
+
+func renderMarkdown(md string) template.HTML {
+	raw := []byte(md)
+	output := markdown.ToHTML(raw, nil, nil)
+
+	return template.HTML(output)
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,16 @@
+package idp
+
+import (
+	"net/url"
+	"strings"
+)
+
+func getBasePath(u url.URL) string {
+	basePath := u.Path
+
+	if basePath == "" || basePath == "/" {
+		return "/"
+	}
+
+	return strings.TrimSuffix(basePath, "/")
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestOptions_GetBasePath(t *testing.T) {
+func Test_GetBasePath(t *testing.T) {
 	testCases := []struct {
 		baseUrl  string
 		basePath string
@@ -24,10 +24,9 @@ func TestOptions_GetBasePath(t *testing.T) {
 	for _, testCase := range testCases {
 		baseUrl, _ := url.Parse(testCase.baseUrl)
 
-		options := &ServerOptions{
-			BaseUrl: *baseUrl,
-		}
+		expected := testCase.basePath
+		actual := getBasePath(*baseUrl)
 
-		require.Equal(t, testCase.basePath, options.getBasePath())
+		require.Equal(t, expected, actual)
 	}
 }


### PR DESCRIPTION
This PR adds the ability to customize the login page with a custom title, Markdown-enabled description, and ability to dump the test user accounts to the page.

- Inject the main configuration into the server in preparation. Refactor and cleanup configuration loading.
- Create LoginPageOptions with custom title, Markdown-enabled description, and ability to dump test user accounts to the page
- Update documentation
